### PR TITLE
Clone object using JSON

### DIFF
--- a/jLouvain.js
+++ b/jLouvain.js
@@ -113,14 +113,7 @@ export const jLouvain = function() {
 
   function clone(obj) {
     if (obj === null || typeof obj !== 'object') return obj;
-
-    var temp = obj.constructor();
-
-    for (var key in obj) {
-      temp[key] = clone(obj[key]);
-    }
-
-    return temp;
+    return  JSON.parse(JSON.stringify(obj));
   }
 
   //Core-Algorithm Related


### PR DESCRIPTION
Prevent an error when the `constructor` property of a POJO is not a function.